### PR TITLE
Fix error handling in alias command

### DIFF
--- a/Villain.py
+++ b/Villain.py
@@ -699,7 +699,7 @@ def main():
 					if len(sessions):
 						if cmd_list[2] in sessions:
 							
-							alias = alias_sanitizer(cmd_list[1]).strip()
+							alias = alias_sanitizer(cmd_list[1])
 							
 							if isinstance(alias, list):
 								print(alias[0])


### PR DESCRIPTION
When a command like `alias x 00112233-44556677-8899aabb` is run with an insufficient alias value, a nasty error message is displayed and the process quits.