### PR TITLE
fix cpu-intensive loops

### DIFF
--- a/Villain.py
+++ b/Villain.py
@@ -899,6 +899,9 @@ def main():
 				else:
 					continue
 		
+			else:
+				sleep(0.1)
+		
 		
 		except KeyboardInterrupt:
 			


### PR DESCRIPTION
These loops cause the python process to use 100% CPU while waiting for a response from clients.
Adding a small delay to the loop fixes that.