### PR TITLE
Catch EOFError at prompt

### DIFF
--- a/Core/villain_core.py
+++ b/Core/villain_core.py
@@ -854,8 +854,8 @@ class Hoaxshell(BaseHTTPRequestHandler):
 			else:
 				raise KeyboardInterrupt
 			
-		
-		except KeyboardInterrupt:
+
+		except (EOFError, KeyboardInterrupt):
 			print('\r')
 			Hoaxshell.deactivate_shell()
 		

--- a/Villain.py
+++ b/Villain.py
@@ -900,7 +900,7 @@ def main():
 					continue
 		
 		
-		except KeyboardInterrupt:
+		except (EOFError, KeyboardInterrupt):
 			
 			Main_prompt.main_prompt_ready = True
 			


### PR DESCRIPTION
Prior to this PR, pressing ctrl+d at the main Villain prompt resulted in termination of the Villain process. This is unexpected. I would expect this to behave identically to ctrl+c - that is, if sessions are open, prompt the user to confirm exit.

Prior to this PR, pressing ctrl+d from within `shell <session id>` would terminate both the shell and the Villain process. This is unexpected. I would expect this to behave identically to ctrl+c - that is, terminate only the shell and return to the Villain prompt.

After this PR, pressing ctrl+d in both scenarios described above will result in identical behavior to pressing ctrl+c.

Tested with Python 3.10.8 on Linux.
