### PR TITLE
Moved from Pycrptodome to Pycryptodomex. It's a drop in replacement

### DIFF
--- a/Core/common.py
+++ b/Core/common.py
@@ -12,7 +12,7 @@ from random import randint, choice, randrange
 from threading import Thread, enumerate as enumerate_threads
 from subprocess import check_output
 from platform import system as get_system_type
-from Crypto.Cipher import AES
+from Cryptodome.Cipher import AES
 from uuid import UUID, uuid4
 from ipaddress import ip_address
 from copy import deepcopy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 gnureadline==8.1.2
 netifaces==0.11.0
-pycryptodome==3.17
+pycryptodomex==3.17
 pyperclip==1.8.2


### PR DESCRIPTION
Fixed error for: ModuleNotFoundError: No module named 'Crypto'. 
This has been changed in Pycryptodome in Pycryptomex module.