### PR TITLE
Added feature to spawn conptyshell if within tmux session

### DIFF
--- a/Villain.py
+++ b/Villain.py
@@ -7,6 +7,7 @@
 
 
 import argparse
+import os
 from subprocess import check_output
 from Core.common import *
 from Core.settings import Hoaxshell_Settings, Core_Server_Settings, TCP_Sock_Handler_Settings, File_Smuggler_Settings
@@ -1285,7 +1286,12 @@ def main():
 							villain_cmd['issuer'] = 'self'
 
 							# Start listener
-							os.system(f'gnome-terminal -- bash -c "stty raw -echo; (stty size; cat) | nc -lvnp {lport}"')
+							# Will spawn in TMUX instead of gnome-terminal if available.
+							if os.getenv("TMUX") is not None:
+								os.system(f'tmux split-window -h "bash -c \'stty raw -echo; (stty size; cat) | nc -lvnp {lport}\'"')
+							else:
+								os.system(f'gnome-terminal -- bash -c "stty raw -echo; (stty size; cat) | nc -lvnp {lport}"')
+							
 							sleep(0.2)
 							Hoaxshell.command_pool[session_id].append(villain_cmd)
 


### PR DESCRIPTION
It's a very small addition to the conptyshell code that allows a user to spawn the whole conptyshell thing in a another tmux pane instead.

This way, it completely removes the requirement of needing gnome-terminal and allows for more flexibility.

I might be able to figure out a way to implement this into the Linux rev shells to allow for shell upgrades.

Hope this helps.

(I am still learning and this may not be optimized code, it checks if we are inside a tmux session by checking if the `tmux` environment variable exists or not.)