### PR TITLE
Update villain_core.py

### DIFF
--- a/Core/villain_core.py
+++ b/Core/villain_core.py
@@ -1479,14 +1479,9 @@ def initiate_hoax_server():
 			exit(f'\n[{DEBUG}] {Hoaxshell.server_name} failed to start (Unknown error occurred).\n')
 
 		if Hoaxshell_Settings.ssl_support:
-			httpd.socket = ssl.wrap_socket (
-				httpd.socket,
-				keyfile = Hoaxshell_Settings.keyfile,
-				certfile = Hoaxshell_Settings.certfile,
-				server_side = True,
-				ssl_version=ssl.PROTOCOL_TLS
-			)
-
+			context = ssl.SSLContext(ssl.PROTOCOL_TLS)
+			context.load_cert_chain(certfile = Hoaxshell_Settings.certfile, keyfile = Hoaxshell_Settings.keyfile)
+			httpd.socket = context.wrap_socket(sock = httpd.socket, server_side= True)
 
 		Hoaxshell_server = Thread(target = httpd.serve_forever, args = (), name = 'hoaxshell_server')
 		Hoaxshell_server.daemon = True


### PR DESCRIPTION
Fixed SSL support for **Python 3.12**. 
Module '**ssl**' had no attribute '**wrap_socket**'.
It is handled with **ssl.SSLContext** which itself has the attribute of **wrap_socket**.
![2024-11-05_18h22_47](https://github.com/user-attachments/assets/690a7099-4e6c-4140-9321-892a80f18b62)
![2024-11-05_18h32_00](https://github.com/user-attachments/assets/5c3caf06-0746-4e8e-9d98-ecf859c20c49)
