### PR TITLE
bugfix: added support for session alias

### DIFF
--- a/Villain.py
+++ b/Villain.py
@@ -1076,7 +1076,7 @@ def main():
 					lhost = parse_lhost(cmd_list[1])
 					try: lport = int(cmd_list[2])
 					except: lport = -1					
-					session_id = cmd_list[3]
+					session_id = Sessions_Manager.alias_to_session_id(cmd_list[3])
 					sessions_check = Sessions_Manager.sessions_check(session_id)
 					
 					if sessions_check[0]:


### PR DESCRIPTION
added support for session alias as per the help text:

```
Villain > help conptyshell

  Automatically runs Invoke-ConPtyShell against a session. A new terminal window with netcat
  listening will pop up (you need to have gnome-terminal installed) and the script will be
  executed on the target as a new process, spawning a fully interactive shell. Currently works
  only for powershell.exe sessions.

  Usage:
  conptyshell <IP or INTERFACE> <PORT> <SESSION ID or ALIAS>
```